### PR TITLE
bump cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:17.04
 
-ENV CLI_VERSION 1.12.0
+ENV CLI_VERSION 1.13.1
 ADD https://jfrog.bintray.com/jfrog-cli-go/${CLI_VERSION}/jfrog-cli-linux-amd64/jfrog /bin/jfrog
 RUN apt update && apt install -y ca-certificates && apt clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Changes

Bump cli version from `1.12.0` to `1.13.1`.

## Reason

I primarily care about the specific release note of "Unified JSON output for the Artifactory commands". 

Old output example:

```
$ jfrog rt u foo.txt app-dev/
[Info] [Thread 2] Uploading artifact: foo.txt
[Info] Uploaded 1 artifacts.
```

New output example:

```
$ jfrog rt u foo.txt app-dev/
[Info] [Thread 2] Uploading artifact: foo.txt
{
  "status": "success",
  "totals": {
    "success": 1,
    "failure": 0
  }
}
```

Multiple other bug fixes are noted on the [release notes](https://bintray.com/jfrog/jfrog-cli-go/jfrog-cli-linux-amd64#release).